### PR TITLE
Adapt to API changes in ghc-mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -454,3 +454,4 @@ testing/addCon/Case2.hs.temp.hs
 /.travis.yaml.old2
 /hcar/HaReTheHaskellRefactorer-AH.out
 /hcar/HaReTheHaskellRefactorer-AH.pdf
+*~

--- a/src/Language/Haskell/Refact/Utils/Utils.hs
+++ b/src/Language/Haskell/Refact/Utils/Utils.hs
@@ -210,11 +210,7 @@ runRefactGhcCd comp initialState opt = do
   let
     runMain :: IO a -> IO a
     runMain progMain = do
-      catches progMain [
-        Handler $ \(GM.GMEWrongWorkingDirectory projDir _curDir) -> do
-          cdAndDo projDir progMain
-        ]
-
+      progMain
     fullComp = runRefactGhc comp initialState opt
 
   runMain fullComp
@@ -456,4 +452,3 @@ serverModsAndFiles m = do
                  $ map summaryNodeSummary $ GHC.reachableG mg modNode
 
   return serverMods
-


### PR DESCRIPTION
ghc-mod 5.5 removes the `GMEWrongWorkingDirectory` constructor and I don’t see a replacement so simply removing the catch should do the trick. I also took the liberty to add a `stack.yaml`. It would be great if you could put out a release relatively fast after ghc-mod releases, so that we can use released deps in `hie`.